### PR TITLE
feat: Mention Each command registration and add members utils 

### DIFF
--- a/commands/main.go
+++ b/commands/main.go
@@ -26,4 +26,38 @@ var Commands = []*discordgo.ApplicationCommand{
 		Name:        utils.CommandNames.Verify,
 		Description: "Generate a link with user specific token to link with RDS backend",
 	},
+	{
+		Name:        utils.CommandNames.MentionEach,
+		Description: "Mention all users with a specific role",
+		Options: []*discordgo.ApplicationCommandOption{
+			// Role Option(Required)
+			{
+				Name:        "role",
+				Description: "The role whose members will be mentioned",
+				Type:        discordgo.ApplicationCommandOptionRole,
+				Required:    true,
+			},
+			// Optional message to include
+			{
+				Name:        "message",
+				Description: "Custom message to accompany the mentions",
+				Type:        discordgo.ApplicationCommandOptionString,
+				Required:    false,
+			},
+			// Dev mode flag: Send individual messages per user
+			{
+				Name:        "dev",
+				Description: "Send individual mentions in separate message",
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+				Required:    false,
+			},
+			// DevTitle mode flag: List users without pinging
+			{
+				Name:        "dev_title",
+				Description: "Show a list of users with the role without pinging them",
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+				Required:    false,
+			},
+		},
+	},
 }

--- a/dtos/commands.go
+++ b/dtos/commands.go
@@ -4,4 +4,5 @@ type CommandNameTypes struct {
 	Hello     string
 	Listening string
 	Verify    string
+	MentionEach string
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -9,4 +9,5 @@ var CommandNames = dtos.CommandNameTypes{
 	Hello:     "hello",
 	Listening: "listening",
 	Verify:    "verify",
+	MentionEach: "mention-each",
 }

--- a/utils/members_utils.go
+++ b/utils/members_utils.go
@@ -1,0 +1,85 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/bwmarrin/discordgo"
+	"slices"
+)
+
+type DiscordSessionInterface interface {
+	GuildMembers(guildID, after string, limit int) ([]*discordgo.Member, error)
+	ChannelMessageSend(channelID, content string) (*discordgo.Message, error)
+}
+
+func GetUsersWithRole(session DiscordSessionInterface, guildID string, roleID string) ([]*discordgo.Member, error) {
+	members, err := session.GuildMembers(guildID, "", 1000)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch guild members: %w", err)
+	}
+
+	var membersWithRole []*discordgo.Member
+	for _, member := range members {
+		if slices.Contains(member.Roles, roleID) {
+			membersWithRole = append(membersWithRole, member)
+		}
+	}
+
+	return membersWithRole, nil
+}
+
+func FormatUserMentions(members []*discordgo.Member) []string {
+	if members == nil {
+		return []string{}
+	}
+	mentions := make([]string, len(members))
+	for i, member := range members {
+		mentions[i] = fmt.Sprintf("<@%s>", member.User.ID)
+	}
+	return mentions
+}
+
+func FormatRoleMention(roleID string) string {
+	return fmt.Sprintf("<@&%s>", roleID)
+}
+
+func JoinMentions(mentions []string, separator string) string {
+	if mentions == nil || len(mentions) == 0 {
+		return ""
+	}
+
+	results := mentions[0]
+	for i := 1; i < len(mentions); i++ {
+		results += separator + mentions[i]
+	}
+
+	return results
+}
+
+
+func FormatMentionResponse(mentions []string, message string) string {
+	if len(mentions) == 0 {
+		return "Sorry no user found under this role."
+	}
+
+	if message == "" {
+		return JoinMentions(mentions, " ")
+	}
+
+	return fmt.Sprintf("%s %s", message, JoinMentions(mentions, " "))
+}
+
+func FormatDevTitleResponse(mentions []string, roleID string) string {
+	count := len(mentions)
+	roleMention := FormatRoleMention(roleID)
+
+	switch count {
+	case 0:
+		return fmt.Sprintf("Found 0 users with the %s role", roleMention)
+	case 1:
+		return fmt.Sprintf("Found 1 user with the %s role: %s", roleMention, mentions[0])
+	default:
+		userList := JoinMentions(mentions, ", ")
+		return fmt.Sprintf("Found %d users with the %s role: %s", count, roleMention, userList)
+	}
+}

--- a/utils/members_utils_test.go
+++ b/utils/members_utils_test.go
@@ -1,0 +1,192 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockDiscordSession struct {
+	mock.Mock
+}
+
+func (m *MockDiscordSession) GuildMembers(guildID, after string, limit int) ([]*discordgo.Member, error) {
+	args := m.Called(guildID, after, limit)
+	return args.Get(0).([]*discordgo.Member), args.Error(1)
+}
+
+func (m *MockDiscordSession) ChannelMessageSend(channelID, content string) (*discordgo.Message, error) {
+	args := m.Called(channelID, content)
+	return args.Get(0).(*discordgo.Message), args.Error(1)
+}
+
+func TestGetUsersWithRole(t *testing.T) {
+	guildID := "testGuild"
+	roleID := "testRole"
+
+	t.Run("returns users with matching role", func(t *testing.T) {
+		mockSession := new(MockDiscordSession)
+		members := []*discordgo.Member{
+			{User: &discordgo.User{ID: "123"}, Roles: []string{"testRole"}},
+			{User: &discordgo.User{ID: "456"}, Roles: []string{"otherRole"}},
+		}
+		mockSession.On("GuildMembers", guildID, "", 1000).Return(members, nil)
+		mockSession.On("ChannelMessageSend", mock.Anything, mock.Anything).Return(&discordgo.Message{}, nil)
+
+		result, err := GetUsersWithRole(mockSession, guildID, roleID)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(result))
+		assert.Equal(t, "123", result[0].User.ID)
+	})
+
+	t.Run("handles error from GuildMembers", func(t *testing.T) {
+		mockSession := new(MockDiscordSession)
+		mockSession.On("GuildMembers", guildID, "", 1000).Return([]*discordgo.Member{}, errors.New("API error"))
+		mockSession.On("ChannelMessageSend", mock.Anything, mock.Anything).Return(&discordgo.Message{}, nil)
+
+		_, err := GetUsersWithRole(mockSession, guildID, roleID)
+		assert.Error(t, err)
+	})
+
+	t.Run("returns empty slice when no users have the role", func(t *testing.T) {
+		mockSession := new(MockDiscordSession)
+		members := []*discordgo.Member{
+			{User: &discordgo.User{ID: "123"}, Roles: []string{"otherRole"}},
+		}
+		mockSession.On("GuildMembers", guildID, "", 1000).Return(members, nil)
+		mockSession.On("ChannelMessageSend", mock.Anything, mock.Anything).Return(&discordgo.Message{}, nil)
+
+		result, err := GetUsersWithRole(mockSession, guildID, roleID)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(result))
+	})
+}
+
+func TestFormatUserMentions(t *testing.T) {
+	t.Run("formats user Mentions correctly", func(t *testing.T) {
+		members := []*discordgo.Member{
+			{User: &discordgo.User{ID: "123"}},
+			{User: &discordgo.User{ID: "456"}},
+		}
+
+		mentions := FormatUserMentions(members)
+		assert.Equal(t, []string{"<@123>", "<@456>"}, mentions)
+	})
+	t.Run("handles empty member list", func(t *testing.T) {
+		mentions := FormatUserMentions([]*discordgo.Member{})
+		assert.Equal(t, []string{}, mentions)
+	})
+	t.Run("handles nil members list", func(t *testing.T) {
+		mentions := FormatUserMentions(nil)
+		assert.Equal(t, []string{}, mentions)
+	})
+}
+
+func TestFormatRoleMention(t *testing.T) {
+	t.Run("format roleID as mention", func(t *testing.T) {
+		roleID := "123456789"
+		mention := FormatRoleMention(roleID)
+		assert.Equal(t, "<@&123456789>", mention)
+	})
+	t.Run("handles empty roleID", func(t *testing.T) {
+		mention := FormatRoleMention("")
+		assert.Equal(t, "<@&>", mention)
+	})
+}
+
+func TestJoinMentions(t *testing.T) {
+	t.Run("joins mentions with space separator", func(t *testing.T) {
+		mentions := []string{"<@123>", "<@456>"}
+		result := JoinMentions(mentions, " ")
+		assert.Equal(t, "<@123> <@456>", result)
+	})
+
+	t.Run("joins mentions with comma separator", func(t *testing.T) {
+		mentions := []string{"<@123>", "<@456>"}
+		result := JoinMentions(mentions, ", ")
+		assert.Equal(t, "<@123>, <@456>", result)
+	})
+
+	t.Run("handles single mention", func(t *testing.T) {
+		mentions := []string{"<@123>"}
+		result := JoinMentions(mentions, ", ")
+		assert.Equal(t, "<@123>", result)
+	})
+
+	t.Run("handles empty mentions", func(t *testing.T) {
+		result := JoinMentions([]string{}, ", ")
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("handles nil mentions", func(t *testing.T) {
+		result := JoinMentions(nil, ", ")
+		assert.Equal(t, "", result)
+	})
+}
+
+func TestFormatMentionResponse(t *testing.T) {
+	t.Run("formats response with message and mentions", func(t *testing.T) {
+		mentions := []string{"<@123>", "<@456>"}
+		message := "Hello"
+		response := FormatMentionResponse(mentions, message)
+		assert.Equal(t, "Hello <@123> <@456>", response)
+	})
+
+	t.Run("formats response with only mentions", func(t *testing.T) {
+		mentions := []string{"<@123>", "<@456>"}
+		response := FormatMentionResponse(mentions, "")
+		assert.Equal(t, "<@123> <@456>", response)
+	})
+
+	t.Run("handles empty mentions", func(t *testing.T) {
+		response := FormatMentionResponse([]string{}, "Hello")
+		assert.Equal(t, "Sorry no user found under this role.", response)
+	})
+
+	t.Run("handles nil mentions", func(t *testing.T) {
+		response := FormatMentionResponse(nil, "Hello")
+		assert.Equal(t, "Sorry no user found under this role.", response)
+	})
+}
+func TestFormatDevTitleResponse(t *testing.T) {
+	roleID := "123456789"
+	roleMention := "<@&" + roleID + ">"
+
+	t.Run("formats response with no users", func(t *testing.T) {
+		response := FormatDevTitleResponse([]string{}, roleID)
+		expected := fmt.Sprintf("Found 0 users with the %s role", roleMention)
+		assert.Equal(t, expected, response)
+	})
+
+	t.Run("formats response with single user", func(t *testing.T) {
+		mentions := []string{"<@123>"}
+		response := FormatDevTitleResponse(mentions, roleID)
+		expected := fmt.Sprintf("Found 1 user with the %s role: %s", roleMention, mentions[0])
+		assert.Equal(t, expected, response)
+	})
+
+	t.Run("formats response with multiple users", func(t *testing.T) {
+		mentions := []string{"<@123>", "<@456>"}
+		response := FormatDevTitleResponse(mentions, roleID)
+		expected := fmt.Sprintf("Found %d users with the %s role: %s", len(mentions), roleMention, JoinMentions(mentions, ", "))
+		assert.Equal(t, expected, response)
+	})
+
+	t.Run("handles nil mentions", func(t *testing.T) {
+		response := FormatDevTitleResponse(nil, roleID)
+		expected := fmt.Sprintf("Found 0 users with the %s role", roleMention)
+		assert.Equal(t, expected, response)
+	})
+
+	t.Run("handles empty role ID", func(t *testing.T) {
+		mentions := []string{"<@123>"}
+		emptyRoleMention := "<@&>"
+		response := FormatDevTitleResponse([]string{"<@123>"}, "")
+		expected := fmt.Sprintf("Found 1 user with the %s role: %s", emptyRoleMention, mentions[0])
+		assert.Equal(t, expected, response)
+	})
+}


### PR DESCRIPTION
* Implemented MentionEach command to mention all users with a specific role.
* Updated command names and constants to include MentionEach.
* Added utility functions for handling user and role mentions.

<!-- Date Here in dd mmm yyyy-->
Date: 10/04/2025
<!--Developer Name Here-->
Developer Name: @Devashish08 

---

## Issue Ticket Number
#70 

## Description
This is first PR for mention each migration command in this PR i have added constants for mention each command and members utils function to get members from discord 

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>
![image](https://github.com/user-attachments/assets/39b77b40-e75a-4034-844e-9c7126db937e)


<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
