### PR TITLE
(1) REFACTOR : Using fmt methods for string concatenation in errorHandler.go

### DIFF
--- a/utils/errorHandler.go
+++ b/utils/errorHandler.go
@@ -29,6 +29,7 @@ func (errorPackage) NewInternalError(response http.ResponseWriter) {
 func formatError(response http.ResponseWriter, message string, status int) {
 	logrus.Error("Message : ", message)
 	response.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	fmt.Fprintf(response, `{"success": false, "message": "%s", "status": %d}`, message, status)
+	errorMessage := fmt.Sprintf(`{"success": false, "message": "%s", "status": %d}`, message, status)
+	http.Error(response, errorMessage, status)
 	return
 }

--- a/utils/errorHandler.go
+++ b/utils/errorHandler.go
@@ -1,8 +1,8 @@
 package utils
 
 import (
+	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/sirupsen/logrus"
 )
@@ -29,6 +29,6 @@ func (errorPackage) NewInternalError(response http.ResponseWriter) {
 func formatError(response http.ResponseWriter, message string, status int) {
 	logrus.Error("Message : ", message)
 	response.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	http.Error(response, `{"success": false, "message": "`+message+`", "status": `+strconv.Itoa(status)+`}`, status)
+	fmt.Fprintf(response, `{"success": false, "message": "%s", "status": %d}`, message, status)
 	return
 }

--- a/utils/errorHandler_test.go
+++ b/utils/errorHandler_test.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type result struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+	Status  int    `json:"status"`
+}
+
+func TestNewBadRequestError(t *testing.T) {
+	response := httptest.NewRecorder()
+	message := "Bad Request"
+	Errors.NewBadRequestError(response, message)
+	assert.Equal(t, http.StatusBadRequest, response.Code)
+	r := &result{}
+	err := json.Unmarshal(response.Body.Bytes(), r)
+	assert.NoError(t, err)
+	assert.Equal(t, message, r.Message)
+}
+
+func TestNewUnauthorisedError(t *testing.T) {
+	t.Run("should return 401 Unauthorised with default message", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		Errors.NewUnauthorisedError(response)
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
+		message := "Unauthorized Access"
+		r := &result{}
+		err := json.Unmarshal(response.Body.Bytes(), r)
+		assert.NoError(t, err)
+		assert.Equal(t, message, r.Message)
+	})
+	t.Run("should return 401 Unauthorised with provided error message", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		Errors.NewUnauthorisedError(response, "test error")
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
+		r := &result{}
+		err := json.Unmarshal(response.Body.Bytes(), r)
+		assert.NoError(t, err)
+		assert.Equal(t, "test error", r.Message)
+	})
+}
+func TestNewInternalError(t *testing.T) {
+	t.Run("should return 500 Internal Server Error with default message", func(t *testing.T) {
+		response := httptest.NewRecorder()
+		Errors.NewInternalError(response)
+		assert.Equal(t, http.StatusInternalServerError, response.Code)
+		message := "Internal Server Error"
+		r := &result{}
+		err := json.Unmarshal(response.Body.Bytes(), r)
+		assert.NoError(t, err)
+		assert.Equal(t, message, r.Message)
+	})
+}


### PR DESCRIPTION

Date: 25 April 2025
<!--Developer Name Here-->
Developer Name: Joy Gupta
https://github.com/Real-Dev-Squad/discord-service/issues/82
---

## Issue Ticket Number
- https://github.com/Real-Dev-Squad/discord-service/issues/82

## Description

Using fmt method for string concatenation

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage

<img width="1400" alt="Screenshot 2025-04-26 at 11 13 26 AM" src="https://github.com/user-attachments/assets/b06bf9df-16b9-4093-acb5-2b7cd53b8957" />
