### PR TITLE
Fix: Properly Respond to Discord Interaction Ping for endpoint verification

### DIFF
--- a/service/discordBaseService.go
+++ b/service/discordBaseService.go
@@ -28,10 +28,10 @@ func DiscordBaseService(response http.ResponseWriter, request *http.Request) {
 	switch message.Type {
 
 	case discordgo.InteractionPing:
-      utils.WriteJSONResponse(response, http.StatusOK, map[string]uint8{
-        "type": uint8(discordgo.InteractionResponsePong),
-      })
-      return
+        utils.WriteJSONResponse(response, http.StatusOK, map[string]uint8{
+         "type": uint8(discordgo.InteractionResponsePong),
+        })
+        return
 
 	case discordgo.InteractionApplicationCommand:
 		MainService(&message)(response, request)

--- a/service/discordBaseService_test.go
+++ b/service/discordBaseService_test.go
@@ -59,14 +59,14 @@ func TestDiscordBaseService(t *testing.T) {
 		rr := httptest.NewRecorder()
 		
 		DiscordBaseService(rr, r)
-				
-		bytes, err:= json.Marshal(map[string]uint8{
-        "type": uint8(discordgo.InteractionResponsePong),
-        })
+
+		responseBytes, err := json.Marshal(map[string]uint8{
+			"type": uint8(discordgo.InteractionResponsePong),
+		})
 		assert.NoError(t, err)
 	
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, string(bytes), rr.Body.String())
+		assert.Equal(t, string(responseBytes), rr.Body.String())
 	})
 
 	t.Run("should return success response when message type is interaction application command", func(t *testing.T) {


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 23/08/2025
<!--Developer Name Here-->
Developer Name: Suvidh Kaushik

---

## Issue Ticket Number

 - #122 

## Description

- Discord verifies our service endpoint by sending an interaction ping 
- We were not properly sending the response for this interaction ping due to which the endpoint was not getting verified
- This PR fixes that issue

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Recordings</summary>

**BEFORE** 

https://github.com/user-attachments/assets/5e1cfc51-ed9d-46b4-8e5a-621c3d4694d5

**AFTER** 

https://github.com/user-attachments/assets/d1b184f6-a555-460e-8a12-f25818139f01


<img width="1358" height="149" alt="Screenshot 2025-08-23 001326" src="https://github.com/user-attachments/assets/c0e57878-58ab-4fc3-ab05-39c5777fce41" />




</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>
<img width="1210" height="84" alt="Screenshot 2025-08-22 235950" src="https://github.com/user-attachments/assets/b50c4afc-e6f6-4038-8e53-08f43d888a9d" />

<img width="1428" height="19" alt="Screenshot 2025-08-23 000017" src="https://github.com/user-attachments/assets/8a233c06-04b3-4588-817e-929f0aa7302f" />



</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the response to a Discord Interaction Ping by sending a simple JSON payload with a "type" key set to `InteractionResponsePong`, instead of a custom response object with "message" and "data" fields.

### Why are these changes being made?

The previous implementation incorrectly responded with an unnecessary payload structure, which may not align with Discord's requirements for verifying endpoints. The updated approach simplifies the response, ensuring compliance and correctness according to Discord's API specification for interaction pings.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->